### PR TITLE
Ch: Results parser now accepts empty project hash (for locally cloned…

### DIFF
--- a/flapy/results_parser.py
+++ b/flapy/results_parser.py
@@ -169,6 +169,7 @@ class PassedFailed:
         # Some junit-xml files actually had name="" in them
         #   -> replace by NaN so they get ignored in the groupby
         self._df["Test_funcname"] = self._df["Test_funcname"].replace("", np.NaN)
+        self._df["Project_Hash"] = self._df["Project_Hash"].replace(np.NaN, "")
 
         # Rows with NaN are ignored by pd.groupby -> fillna
         self._df["Test_filename"] = self._df["Test_filename"].fillna("")


### PR DESCRIPTION
… projects).

Results Parser threw an error when working with a passed_failed.csv that had no Git Hash (NaN). Now it considers an empty Git Hash to be an empty String.